### PR TITLE
Fixed bug where player1Type was updated when player2Code was uploaded

### DIFF
--- a/src/main/java/connectX/WelcomeDash.java
+++ b/src/main/java/connectX/WelcomeDash.java
@@ -226,11 +226,11 @@ public class WelcomeDash implements Initializable {
             else if (Constants.exeFileFilter.accept(file) || Constants.classFileFilter.accept(file)||Constants.pythonFileFilter.accept(file)) {
                 if (Constants.classFileFilter.accept(file)) {
                     this.updateTime(0,false);
-                    Players.getPlayers().player1Type=1;
+                    Players.getPlayers().player2Type=1;
                 }
                 else if (Constants.pythonFileFilter.accept(file)) {
                     this.updateTime(0,true);
-                    Players.getPlayers().player1Type=2;
+                    Players.getPlayers().player2Type=2;
                 }
                 Players.getPlayers().player2Ready = true;
                 try {


### PR DESCRIPTION
https://github.com/Arc29/ConnectX-CodeWarriors/blob/3de20c73978c8b4d48baff0311edee64c8818920/src/main/java/connectX/WelcomeDash.java#L227-L234
The function `void player2Code(final ActionEvent event)` which is supposed to update `player2Type` updates `player1Type` in some cases (shown above).

As a result, `player2Type` never gets updated and will always be its default value which is `0`.

**This means that time scaling will not be applied to the move time of Player 2**.
https://github.com/Arc29/ConnectX-CodeWarriors/blob/3de20c73978c8b4d48baff0311edee64c8818920/src/main/java/connectX/WelcomeDash.java#L261-L264
In the code above, the function which applies time scaling for a player `void updateTime(final int playerId, final boolean isPython)`  whenever the move time is updated, is only called if the file for the player has been uploaded and if the player type is not 0 (but since player 2 always has type 0, it will never be scaled).

So to fix this, I made changes so that `player2Type` was updated